### PR TITLE
Fix RuntimeError: context has already been set

### DIFF
--- a/sko/tools.py
+++ b/sko/tools.py
@@ -6,7 +6,10 @@ import sys
 import multiprocessing
 
 if sys.platform != 'win32':
-    multiprocessing.set_start_method('fork')
+    try:
+        multiprocessing.set_start_method('fork')
+    except RuntimeError:
+        pass
 
 
 def set_run_mode(func, mode):


### PR DESCRIPTION
After invoking torch.multiprocessing.set_start_method, importing sko will result in "RuntimeError: context has already been set". Here is a simple code to reproduce it(to be run in a non-win32 environment).

```python
import torch.multiprocessing as mp
mp.set_start_method("spawn")

import sko # <-- RuntimeError occurs.
```

This pull request should fix it. (Reference: <https://github.com/pytorch/pytorch/issues/3492#issuecomment-392977006>)
Possible related Issue: #146