### PR TITLE
fix: support numpy 1.20, use int instead of numpy.int

### DIFF
--- a/sko/ACA.py
+++ b/sko/ACA.py
@@ -23,7 +23,7 @@ class ACA_TSP:
         self.prob_matrix_distance = 1 / (distance_matrix + 1e-10 * np.eye(n_dim, n_dim))  # 避免除零错误
 
         self.Tau = np.ones((n_dim, n_dim))  # 信息素矩阵，每次迭代都会更新
-        self.Table = np.zeros((size_pop, n_dim)).astype(np.int)  # 某一代每个蚂蚁的爬行路径
+        self.Table = np.zeros((size_pop, n_dim)).astype(int)  # 某一代每个蚂蚁的爬行路径
         self.y = None  # 某一代每个蚂蚁的爬行总距离
         self.generation_best_X, self.generation_best_Y = [], []  # 记录各代的最佳情况
         self.x_best_history, self.y_best_history = self.generation_best_X, self.generation_best_Y  # 历史原因，为了保持统一


### PR DESCRIPTION
numpy 1.20 and newer will report this error and stop running:

AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'inf'