### PR TITLE
Joblib support in parallel function

### DIFF
--- a/sko/tools.py
+++ b/sko/tools.py
@@ -77,7 +77,7 @@ def func_transformer(func, n_processes):
         set_run_mode(func, 'vectorization')
 
     mode = getattr(func, 'mode', 'others')
-    valid_mode = ('common', 'multithreading', 'multiprocessing', 'vectorization', 'cached', 'others')
+    valid_mode = ('common', 'multithreading', 'multiprocessing', 'vectorization', 'cached', 'joblib', 'others')
     assert mode in valid_mode, 'valid mode should be in ' + str(valid_mode)
     if mode == 'vectorization':
         return func
@@ -113,7 +113,16 @@ def func_transformer(func, n_processes):
             return np.array(pool.map(func, X))
 
         return func_transformed
-
+        
+    elif mode == "joblib":
+        from joblib import Parallel, delayed
+        def func_transformed(X):
+            res = Parallel(n_jobs=-1, batch_size='auto')(
+                delayed(func)(x) for x in X
+            )
+            return np.array(res)
+        return func_transformed
+        
     else:  # common
         def func_transformed(X):
             return np.array([func(x) for x in X])


### PR DESCRIPTION
Joblib is more convenient and robust to use than multiprocessing, making it more suitable for the field of scientific computing. I hope to add support for this library